### PR TITLE
Add missing includes

### DIFF
--- a/include/BMJson.h
+++ b/include/BMJson.h
@@ -29,6 +29,9 @@ SOFTWARE.
 #include <unordered_map>
 #include <utility>
 #include <variant>
+#include <cctype>
+#include <format>
+#include <string>
 
 #define ThrowParserError(...)\
     ThrowError(__VA_ARGS__);\


### PR DESCRIPTION
- Needs `<cctype>` for `std::isdigit`
- Needs `<format>` for `std::format`
- Needs `<string>` for `std::to_string` / `std::string`